### PR TITLE
[STEP17]docker 이용해 kafka 설치 및 연결 통합 테스트 작성

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,10 @@ dependencies {
     // Redisson
     implementation("org.redisson:redisson-spring-boot-starter:3.22.0")
 
+    // kafka
+    implementation("org.springframework.kafka:spring-kafka")
+
+
 }
 
 // QueryDSL Q 클래스 생성 디렉토리 설정

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,8 @@ dependencies {
     // Lombok
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
+    testImplementation("org.projectlombok:lombok")
+    testAnnotationProcessor("org.projectlombok:lombok")
 
     // QueryDSL 의존성 추가
     implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta") // QueryDSL JPA 모듈 (Jakarta API 지원)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     testImplementation("org.testcontainers:mysql")
     testImplementation("com.redis.testcontainers:testcontainers-redis:1.6.4")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation("org.testcontainers:kafka")
 
     // Swagger UI
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,16 +19,15 @@ services:
       - 6379:6379
     command: redis-server
 
-  kafka:
+  kafka-1:
     image: confluentinc/cp-kafka:latest
-    container_name: kraft-kafka
+    container_name: kafka-1
     ports:
       - "9092:9092"
-      - "9093:9093"
     environment:
       KAFKA_NODE_ID: 1
       KAFKA_PROCESS_ROLES: broker,controller
-      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@localhost:9093
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka-1:9093,2@kafka-2:9093,3@kafka-3:9093
       KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
@@ -37,7 +36,45 @@ services:
       KAFKA_LOG_DIRS: /tmp/kraft-composed-kafka
       CLUSTER_ID: rbjf_apCTCWPgOnHC3fb3w
     volumes:
-      - ./data/kafka:/tmp/kraft-composed-kafka
+      - ./data/kafka-1:/tmp/kraft-composed-kafka
+
+  kafka-2:
+    image: confluentinc/cp-kafka:latest
+    container_name: kafka-2
+    ports:
+      - "9094:9092"
+    environment:
+      KAFKA_NODE_ID: 2
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka-1:9093,2@kafka-2:9093,3@kafka-3:9093
+      KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9094
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LOG_DIRS: /tmp/kraft-composed-kafka
+      CLUSTER_ID: rbjf_apCTCWPgOnHC3fb3w
+    volumes:
+      - ./data/kafka-2:/tmp/kraft-composed-kafka
+
+  kafka-3:
+    image: confluentinc/cp-kafka:latest
+    container_name: kafka-3
+    ports:
+      - "9096:9092"
+    environment:
+      KAFKA_NODE_ID: 3
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka-1:9093,2@kafka-2:9093,3@kafka-3:9093
+      KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9096
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LOG_DIRS: /tmp/kraft-composed-kafka
+      CLUSTER_ID: rbjf_apCTCWPgOnHC3fb3w
+    volumes:
+      - ./data/kafka-3:/tmp/kraft-composed-kafka
 
 networks:
   default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     command: redis-server
 
   kafka:
-    image: confluentinc/cp-kafka:7.5.0
+    image: confluentinc/cp-kafka:latest
     container_name: kraft-kafka
     ports:
       - "9092:9092"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,26 @@ services:
       - 6379:6379
     command: redis-server
 
+  kafka:
+    image: confluentinc/cp-kafka:7.5.0
+    container_name: kraft-kafka
+    ports:
+      - "9092:9092"
+      - "9093:9093"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@localhost:9093
+      KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LOG_DIRS: /tmp/kraft-composed-kafka
+      CLUSTER_ID: rbjf_apCTCWPgOnHC3fb3w
+    volumes:
+      - ./data/kafka:/tmp/kraft-composed-kafka
+
 networks:
   default:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,62 +19,36 @@ services:
       - 6379:6379
     command: redis-server
 
-  kafka-1:
-    image: confluentinc/cp-kafka:latest
-    container_name: kafka-1
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.5.0
+    container_name: zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+
+  kafka:
+    image: confluentinc/cp-kafka:7.5.0
+    container_name: kafka
     ports:
       - "9092:9092"
     environment:
-      KAFKA_NODE_ID: 1
-      KAFKA_PROCESS_ROLES: broker,controller
-      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka-1:9093,2@kafka-2:9093,3@kafka-3:9093
-      KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_LOG_DIRS: /tmp/kraft-composed-kafka
-      CLUSTER_ID: rbjf_apCTCWPgOnHC3fb3w
-    volumes:
-      - ./data/kafka-1:/tmp/kraft-composed-kafka
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    depends_on:
+      - zookeeper
 
-  kafka-2:
-    image: confluentinc/cp-kafka:latest
-    container_name: kafka-2
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    container_name: kafka-ui
     ports:
-      - "9094:9092"
+      - "8081:8080"
     environment:
-      KAFKA_NODE_ID: 2
-      KAFKA_PROCESS_ROLES: broker,controller
-      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka-1:9093,2@kafka-2:9093,3@kafka-3:9093
-      KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9094
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_LOG_DIRS: /tmp/kraft-composed-kafka
-      CLUSTER_ID: rbjf_apCTCWPgOnHC3fb3w
-    volumes:
-      - ./data/kafka-2:/tmp/kraft-composed-kafka
-
-  kafka-3:
-    image: confluentinc/cp-kafka:latest
-    container_name: kafka-3
-    ports:
-      - "9096:9092"
-    environment:
-      KAFKA_NODE_ID: 3
-      KAFKA_PROCESS_ROLES: broker,controller
-      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka-1:9093,2@kafka-2:9093,3@kafka-3:9093
-      KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9096
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_LOG_DIRS: /tmp/kraft-composed-kafka
-      CLUSTER_ID: rbjf_apCTCWPgOnHC3fb3w
-    volumes:
-      - ./data/kafka-3:/tmp/kraft-composed-kafka
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092
+    depends_on:
+      - kafka
 
 networks:
   default:

--- a/src/main/java/kr/hhplus/be/server/domain/dataplatform/DataPlatformClient.java
+++ b/src/main/java/kr/hhplus/be/server/domain/dataplatform/DataPlatformClient.java
@@ -11,7 +11,7 @@ public class DataPlatformClient {
     public void sendData(OrderCreateEvent orderCreateEvent) {
         log.info("DataPlatformClient sendData {}", orderCreateEvent.toString());
         try {
-            Thread.sleep(5000);
+            Thread.sleep(100);
         } catch (InterruptedException e) {
             log.warn("DataPlatformClient sendData exception", e);
             Thread.currentThread().interrupt();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,10 @@ spring:
       port: 6379
   kafka:
     bootstrap-servers: localhost:9092
+    producer:
+      bootstrap-servers: localhost:9092
+    consumer:
+      bootstrap-servers: localhost:9092
 
 springdoc:
   swagger-ui:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,21 +30,31 @@ spring:
       port: 6379
   kafka:
     bootstrap-servers: localhost:9092
+    properties:
+      auto:
+        offset.reset: earliest
+        create.topics.enable: false
     producer:
-      bootstrap-servers: localhost:9092
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
     consumer:
-      bootstrap-servers: localhost:9092
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.apache.kafka.common.serialization.ByteArrayDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
       properties:
         enable-auto-commit: false
+        spring:
+          json:
+            trusted:
+              packages: "*"
 
 springdoc:
   swagger-ui:
     enabled: true
     path: /swagger-ui.html
+
+order-api:
+  order-created:
+    topic-name: "order-created"
 
 ---
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,8 +32,14 @@ spring:
     bootstrap-servers: localhost:9092
     producer:
       bootstrap-servers: localhost:9092
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
     consumer:
       bootstrap-servers: localhost:9092
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.ByteArrayDeserializer
+      properties:
+        enable-auto-commit: false
 
 springdoc:
   swagger-ui:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,8 @@ spring:
     redis:
       host: localhost
       port: 6379
+  kafka:
+    bootstrap-servers: localhost:9092
 
 springdoc:
   swagger-ui:

--- a/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
+++ b/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
@@ -7,6 +7,8 @@ import org.springframework.boot.testcontainers.service.connection.ServiceConnect
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.kafka.ConfluentKafkaContainer;
+import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @Configuration
@@ -14,6 +16,7 @@ class TestcontainersConfiguration {
 
 	public static final MySQLContainer<?> MYSQL_CONTAINER;
 	public static final RedisContainer REDIS_CONTAINER;
+	public static final ConfluentKafkaContainer KAFKA_CONTAINER;
 
 	static {
 		MYSQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
@@ -33,6 +36,14 @@ class TestcontainersConfiguration {
 		// Redis 연결 정보를 Spring 환경 변수에 추가
 		System.setProperty("spring.data.redis.host", REDIS_CONTAINER.getHost());
 		System.setProperty("spring.data.redis.port", REDIS_CONTAINER.getMappedPort(6379).toString());
+
+		KAFKA_CONTAINER = new ConfluentKafkaContainer("confluentinc/cp-kafka:latest");
+		KAFKA_CONTAINER.start();
+
+		System.setProperty("spring.kafka.bootstrap-servers", KAFKA_CONTAINER.getBootstrapServers());
+		System.setProperty("spring.kafka.producer.bootstrap-servers", KAFKA_CONTAINER.getBootstrapServers());
+		System.setProperty("spring.kafka.consumer.bootstrap-servers", KAFKA_CONTAINER.getBootstrapServers());
+
 	}
 
 	@PreDestroy
@@ -42,6 +53,9 @@ class TestcontainersConfiguration {
 		}
 		if (REDIS_CONTAINER.isRunning()) {
 			REDIS_CONTAINER.stop();
+		}
+		if (KAFKA_CONTAINER.isRunning()) {
+			KAFKA_CONTAINER.stop();
 		}
 	}
 }

--- a/src/test/java/kr/hhplus/be/server/infrastructure/kafka/KafkaTest.java
+++ b/src/test/java/kr/hhplus/be/server/infrastructure/kafka/KafkaTest.java
@@ -2,7 +2,10 @@ package kr.hhplus.be.server.infrastructure.kafka;
 import kr.hhplus.be.server.support.IntegrationTestSupport;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -10,7 +13,9 @@ import java.util.concurrent.TimeUnit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-class KafkaTest extends IntegrationTestSupport {
+@Testcontainers
+@SpringBootTest
+class KafkaTest {
 
     @Autowired
     private TestProducer testProducer;
@@ -34,9 +39,5 @@ class KafkaTest extends IntegrationTestSupport {
                 .atMost(10, TimeUnit.SECONDS)
                 .untilAsserted(() -> assertThat(testConsumer.getMessages())
                         .hasSize(cnt));
-
-        for (int i = 0; i < messages.size(); i++) {
-            assertThat(testConsumer.getMessages().get(i)).isEqualTo(messages.get(i));
-        }
     }
 }

--- a/src/test/java/kr/hhplus/be/server/infrastructure/kafka/KafkaTest.java
+++ b/src/test/java/kr/hhplus/be/server/infrastructure/kafka/KafkaTest.java
@@ -1,0 +1,42 @@
+package kr.hhplus.be.server.infrastructure.kafka;
+import kr.hhplus.be.server.support.IntegrationTestSupport;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+class KafkaTest extends IntegrationTestSupport {
+
+    @Autowired
+    private TestProducer testProducer;
+    @Autowired
+    private TestConsumer testConsumer;
+    private final String TOPIC = "test-topic";
+
+    @Test
+    void Kafka_연동_테스트() {
+        // given
+        List<String> messages = new ArrayList<>();
+        int cnt = 5;
+        for (int i = 0; i < cnt; i++) {
+            String message = "Kafka 연동 테스트 " + i;
+            testProducer.send(TOPIC, message);
+            messages.add(message);
+        }
+
+        // when // then
+        await().pollDelay(2, TimeUnit.SECONDS)
+                .atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(testConsumer.getMessages())
+                        .hasSize(cnt));
+
+        for (int i = 0; i < messages.size(); i++) {
+            assertThat(testConsumer.getMessages().get(i)).isEqualTo(messages.get(i));
+        }
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/infrastructure/kafka/KafkaTest.java
+++ b/src/test/java/kr/hhplus/be/server/infrastructure/kafka/KafkaTest.java
@@ -1,43 +1,36 @@
 package kr.hhplus.be.server.infrastructure.kafka;
-import kr.hhplus.be.server.support.IntegrationTestSupport;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.testcontainers.junit.jupiter.Testcontainers;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-@Testcontainers
 @SpringBootTest
 class KafkaTest {
+    private static final String TOPIC = "test";
+    private static final AtomicInteger counter = new AtomicInteger(0);
 
     @Autowired
-    private TestProducer testProducer;
-    @Autowired
-    private TestConsumer testConsumer;
-    private final String TOPIC = "test-topic";
+    private KafkaTemplate<String, Object> producer;
+
+    @KafkaListener(topics = TOPIC, groupId = "test_group")
+    public void listen(String message) {
+        counter.incrementAndGet();
+    }
 
     @Test
-    void Kafka_연동_테스트() {
-        // given
-        List<String> messages = new ArrayList<>();
-        int cnt = 5;
-        for (int i = 0; i < cnt; i++) {
-            String message = "Kafka 연동 테스트 " + i;
-            testProducer.send(TOPIC, message);
-            messages.add(message);
-        }
-
-        // when // then
-        await().pollDelay(2, TimeUnit.SECONDS)
-                .atMost(10, TimeUnit.SECONDS)
-                .untilAsserted(() -> assertThat(testConsumer.getMessages())
-                        .hasSize(cnt));
+    void kafkaTest() {
+        producer.send(TOPIC, "Kafka Test");
+        await()
+                .pollInterval(Duration.ofMillis(300))
+                .atMost(Duration.ofSeconds(2))
+                .untilAsserted(() -> assertThat(counter.get()).isEqualTo(1L));
     }
 }

--- a/src/test/java/kr/hhplus/be/server/infrastructure/kafka/TestConsumer.java
+++ b/src/test/java/kr/hhplus/be/server/infrastructure/kafka/TestConsumer.java
@@ -1,0 +1,20 @@
+package kr.hhplus.be.server.infrastructure.kafka;
+
+import lombok.Getter;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Component
+public class TestConsumer {
+
+    private final List<String> messages = new ArrayList<>();
+
+    @KafkaListener(topics = "test-topic", groupId = "test-group")
+    public void listen(String message) {
+        messages.add(message);
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/infrastructure/kafka/TestProducer.java
+++ b/src/test/java/kr/hhplus/be/server/infrastructure/kafka/TestProducer.java
@@ -1,0 +1,16 @@
+package kr.hhplus.be.server.infrastructure.kafka;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TestProducer {
+
+    @Autowired
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    public void send(String topic, String message) {
+        kafkaTemplate.send(topic, message);
+    }
+}


### PR DESCRIPTION
## PR 설명
- kafka 설정 
  - application.yml, docker-compose.yml 51e0a14
- kafka 연결 통합 테스트 작성
   - testContainer 설정(TestcontainersConfiguration.java) 99cb70e
   - 통합 테스트 작성 2859e5d

## 리뷰 포인트
질문1.  Testcontainers 설정 관련해서 질문 드립니다. 현재 TestcontainersConfiguration.java 파일 안에 Redis, MySQL, Kafka 설정이 모두 작성되어 있는데, 각 컨테이너 설정을 분리하고 싶습니다. 그런데 제가 잘 못해서 그런지 분리가 쉽지 않더라구요. 
코치님께서는 Redis, MySQL, Kafka와 같은 개별 컨테이너 설정을 어떤 방식으로 구성하시는지 궁금합니다. 예를 들어, 추상화해서 필요한 테스트에서만 상속받는 방식으로 하시는지, 아니면 다른 효과적인 구조가 있는지 조언 부탁드립니다.

## Definition of Done (DoD)
- [x] 카프카 세팅 51e0a14
- [x] 카프카 테스트 컨테이너 설정 추가 99cb70e
- [x] kafka 연결 통합 테스트 작성 2859e5d