### PR TITLE
[Config/Test] test 프로파일 설정 개선 및 테스트 공통 설정 일원화  

### DIFF
--- a/src/main/java/kr/hhplus/be/server/interfaces/api/common/GlobalExceptionHandler.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/api/common/GlobalExceptionHandler.java
@@ -3,10 +3,7 @@ package kr.hhplus.be.server.interfaces.api.common;
 import kr.hhplus.be.server.domain.support.exception.CustomException;
 import kr.hhplus.be.server.domain.support.exception.ErrorCode;
 import kr.hhplus.be.server.domain.support.exception.ErrorResponse;
-import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.transaction.TransactionSystemException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -72,12 +72,15 @@ server:
 spring.config.activate.on-profile: test
 
 spring:
+  sql:
+    init:
+      mode: never
   jpa:
-    open-in-view: true
+    open-in-view: false
     generate-ddl: true
     show-sql: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
   kafka:
     properties:
       auto:

--- a/src/test/java/kr/hhplus/be/server/domain/product/service/ProductServiceCacheTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/product/service/ProductServiceCacheTest.java
@@ -1,9 +1,9 @@
 package kr.hhplus.be.server.domain.product.service;
 
 import kr.hhplus.be.server.domain.product.repository.ProductRepository;
+import kr.hhplus.be.server.support.IntegrationTestSupport;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cache.CacheManager;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import java.time.LocalDate;
@@ -11,8 +11,7 @@ import java.time.LocalDate;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@SpringBootTest
-public class ProductServiceCacheTest {
+public class ProductServiceCacheTest extends IntegrationTestSupport {
 
     @Autowired
     private ProductService productService;


### PR DESCRIPTION
- [x] test 프로파일 JPA 설정 개선 (open-in-view, ddl-auto, sql.init.mode)
- [x] ProductServiceCacheTest를 IntegrationTestSupport 상속으로 변경 